### PR TITLE
Update to Return Headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loke/http-client",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/http-client",
-      "version": "2.0.0",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "got": "^14.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-client",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "A simple yet powerful HTTP client for making requests, measuring performance, and recording metrics for observability. The implementation includes support for custom headers, URL templating, and Prometheus metrics.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ interface Result<T> {
   timings?: Timings;
   statusCode?: number;
   body?: T;
+  headers?: Headers;
 }
 
 type Method =
@@ -130,6 +131,7 @@ export class HTTPClient {
       const result: Result<T> = {
         statusCode: response.status,
         body: (responseBody === "" ? undefined : responseBody) as T,
+        headers: Object.fromEntries(response.headers),
         timings: {
           phases: {
             total: endTime - startTime,

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export class HTTPClient {
     this.maxRedirects = maxRedirects;
   }
 
-  async request<T>(
+  async request(
     method: Method,
     pathTemplate: string,
     params = {},
@@ -130,7 +130,7 @@ export class HTTPClient {
 
       const result: Result = {
         statusCode: response.status,
-        body: (responseBody === "" ? undefined : responseBody) as T,
+        body: responseBody === "" ? undefined : responseBody,
         headers: Object.fromEntries(response.headers),
         timings: {
           phases: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,10 +43,10 @@ interface Timings {
   };
 }
 
-interface Result<T> {
+interface Result {
   timings?: Timings;
   statusCode?: number;
-  body?: T;
+  body?: unknown;
   headers?: Headers;
 }
 
@@ -87,7 +87,7 @@ export class HTTPClient {
     params = {},
     body?: unknown,
     options?: RequestInit
-  ): Promise<Result<T>> {
+  ): Promise<Result> {
     const path = parseUrlTemplate(pathTemplate);
     const url = new URL(path.expand(params), this.baseUrl);
 
@@ -128,7 +128,7 @@ export class HTTPClient {
 
       const responseBody = await this.parseResponseBody(response);
 
-      const result: Result<T> = {
+      const result: Result = {
         statusCode: response.status,
         body: (responseBody === "" ? undefined : responseBody) as T,
         headers: Object.fromEntries(response.headers),
@@ -141,10 +141,10 @@ export class HTTPClient {
 
       this.recordMetrics(result, method, pathTemplate);
 
-      return this._handlerResponse<T>(result);
+      return this._handlerResponse(result);
     } catch (error) {
       const endTime = performance.now();
-      const result: Result<T> = {
+      const result: Result = {
         statusCode: 0,
         timings: {
           phases: {
@@ -197,7 +197,7 @@ export class HTTPClient {
   }
 
   private recordMetrics(
-    result: Result<unknown>,
+    result: Result,
     method: string,
     pathTemplate: string
   ) {
@@ -226,7 +226,7 @@ export class HTTPClient {
     });
   }
 
-  protected _handlerResponse<T>(res: Result<T>): Result<T> {
+  protected _handlerResponse(res: Result): Result {
     return res;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,10 +43,10 @@ interface Timings {
   };
 }
 
-interface Result {
+interface Result<T> {
   timings?: Timings;
   statusCode?: number;
-  body?: unknown;
+  body?: T;
 }
 
 type Method =
@@ -80,13 +80,13 @@ export class HTTPClient {
     this.maxRedirects = maxRedirects;
   }
 
-  async request(
+  async request<T>(
     method: Method,
     pathTemplate: string,
     params = {},
     body?: unknown,
     options?: RequestInit
-  ): Promise<Result> {
+  ): Promise<Result<T>> {
     const path = parseUrlTemplate(pathTemplate);
     const url = new URL(path.expand(params), this.baseUrl);
 
@@ -127,9 +127,9 @@ export class HTTPClient {
 
       const responseBody = await this.parseResponseBody(response);
 
-      const result: Result = {
+      const result: Result<T> = {
         statusCode: response.status,
-        body: responseBody === "" ? undefined : responseBody,
+        body: (responseBody === "" ? undefined : responseBody) as T,
         timings: {
           phases: {
             total: endTime - startTime,
@@ -139,10 +139,10 @@ export class HTTPClient {
 
       this.recordMetrics(result, method, pathTemplate);
 
-      return this._handlerResponse(result);
+      return this._handlerResponse<T>(result);
     } catch (error) {
       const endTime = performance.now();
-      const result: Result = {
+      const result: Result<T> = {
         statusCode: 0,
         timings: {
           phases: {
@@ -195,7 +195,7 @@ export class HTTPClient {
   }
 
   private recordMetrics(
-    result: Result,
+    result: Result<unknown>,
     method: string,
     pathTemplate: string
   ) {
@@ -224,7 +224,7 @@ export class HTTPClient {
     });
   }
 
-  protected _handlerResponse(res: Result): Result {
+  protected _handlerResponse<T>(res: Result<T>): Result<T> {
     return res;
   }
 


### PR DESCRIPTION
This pull request includes changes to the `@loke/http-client` package to update its version and add support for response headers in the `Result` interface and `HTTPClient` class.

Enhancements to HTTP client:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R50): Added `headers` property to the `Result` interface to include response headers in the result.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R134): Modified the `HTTPClient` class to populate the `headers` property in the `Result` object with the response headers.